### PR TITLE
#1: feat add a scheduler to getallplayers call

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>com.example</groupId>
     <artifactId>FantasyFootball</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.2-SNAPSHOT</version>
     <name>demo</name>
     <description>Demo project for Spring Boot</description>
     <properties>

--- a/src/main/java/com/fantasy/football/configuration/FantasySchedulingConfig.java
+++ b/src/main/java/com/fantasy/football/configuration/FantasySchedulingConfig.java
@@ -1,0 +1,9 @@
+package com.fantasy.football.configuration;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class FantasySchedulingConfig {
+}

--- a/src/main/java/com/fantasy/football/scheduler/FantasySavingServiceScheduler.java
+++ b/src/main/java/com/fantasy/football/scheduler/FantasySavingServiceScheduler.java
@@ -1,0 +1,22 @@
+package com.fantasy.football.scheduler;
+
+import com.fantasy.football.service.FantasySavingScheduledService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class FantasySavingServiceScheduler {
+
+    @Autowired
+    private FantasySavingScheduledService fantasySavingScheduledService;
+
+    @Scheduled(fixedDelayString = "${fantasy.service.schedule.interval.saveAllPlayers:600000}", initialDelay = 3000)
+    public void scheduleSaveAllPlayers() {
+        log.info("saveAllPlayers scheduled, now being run");
+        fantasySavingScheduledService.saveAllPlayers();
+    }
+
+}

--- a/src/main/java/com/fantasy/football/service/FantasySavingScheduledService.java
+++ b/src/main/java/com/fantasy/football/service/FantasySavingScheduledService.java
@@ -8,21 +8,19 @@ import lombok.extern.slf4j.Slf4j;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.stereotype.Service;
 
-@RestController
 @Slf4j
+@Service
 public class FantasySavingScheduledService {
+
     @Autowired
     private FantasyClient fantasyClient;
 
     @Autowired
     private PlayerRepository playerRepository;
 
-
-    @GetMapping("/saveAllPlayers")
-    public String saveAllPlayers() {
+    public void saveAllPlayers() {
         Gson gson = new Gson();
 
         JSONObject allInfo = new JSONObject(fantasyClient.getAll());
@@ -44,6 +42,6 @@ public class FantasySavingScheduledService {
 
             playerRepository.save(currentPlayer);
         }
-        return "Saved all players :)";
+        log.info("Saved all players :)");
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,3 +4,6 @@ spring.mvc.log-request-details=true
 
 spring.data.mongodb.uri=mongodb+srv://readWrite:uyLCTGwrs0FaovTj@cluster0.ewqtwli.mongodb.net/
 spring.data.mongodb.database=Fantasy
+
+#Interval to query API for players in milliseconds
+fantasy.service.schedule.interval.saveAllPlayers=600000


### PR DESCRIPTION
Swaps the GetMapping for saving players and instead uses Spring Boot scheduler to query given a property in milliseconds. Defaults to every 10 minutes. Since it's no longer an HTTP query, I also moved the saved all players message to the log.